### PR TITLE
Add required image for aws/node-termination-handler

### DIFF
--- a/mirror/required-images.txt
+++ b/mirror/required-images.txt
@@ -8,5 +8,9 @@
 # gcr.io/google_containers/kube-apiserver:v1.12.8
 k8s.gcr.io/echoserver:1.4
 
+# aws/node-termination-handler for Amazon EKS
+# see - https://github.com/aws/aws-node-termination-handler
+# defined in the chart - https://github.com/aws/aws-node-termination-handler/blob/79bf81f618de474f86636120a40438a47a4e2869/config/helm/aws-node-termination-handler/values.yaml#L5-L7
+amazon/aws-node-termination-handler:v1.3.1
 
 


### PR DESCRIPTION
**aws/node-termination-handler** for Amazon EKS

see - https://github.com/aws/aws-node-termination-handler

defined in the chart:

https://github.com/aws/aws-node-termination-handler/blob/79bf81f618de474f86636120a40438a47a4e2869/config/helm/aws-node-termination-handler/values.yaml#L5-L7