### PR TITLE
Add fluent/fluentd-kubernetes-daemonset:v1.1-debian-elasticsearch

### DIFF
--- a/mirror/required-images.txt
+++ b/mirror/required-images.txt
@@ -41,3 +41,5 @@ quay.io/jetstack/cert-manager-controller:v0.16.0
 quay.io/jetstack/cert-manager-webhook:v0.16.0
 quay.io/jetstack/cert-manager-acmesolver:v0.16.0
 
+# needed for a fluentd deamonset which pushes logs in a elastic search cluster
+fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch


### PR DESCRIPTION
Added most recent tag for the requested docker image:
fluent/fluentd-kubernetes-daemonset:v1.1-debian-elasticsearch