### PR TITLE
Add tekton related docker images

### DIFF
--- a/mirror/required-images.txt
+++ b/mirror/required-images.txt
@@ -11,3 +11,14 @@ quay.io/k8scsi/csi-attacher:v2.2.0
 quay.io/k8scsi/livenessprobe:v2.1.0
 quay.io/k8scsi/csi-snapshotter:v2.1.1
 k8s.gcr.io/external-dns/external-dns:v0.7.6
+gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.20.1
+gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.20.1
+gcr.io/google.com/cloudsdktool/cloud-sdk:302.0.0-slim
+gcr.io/distroless/base:debug
+gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook:v0.20.1
+gcr.io/tekton-releases/github.com/tektoncd/dashboard/cmd/dashboard:v0.13.0
+gcr.io/tekton-releases/github.com/tektoncd/operator/cmd/manager:v0.15.2-1
+gcr.io/tekton-releases/github.com/tektoncd/triggers/cmd/controller:v0.11.1
+gcr.io/tekton-releases/github.com/tektoncd/triggers/cmd/eventlistenersink:v0.11.1
+gcr.io/tekton-releases/github.com/tektoncd/triggers/cmd/interceptors:v0.11.1
+gcr.io/tekton-releases/github.com/tektoncd/triggers/cmd/webhook:v0.11.1


### PR DESCRIPTION
The docker images added are coming from:

- https://github.com/tektoncd/pipeline/releases/tag/v0.20.1
- https://github.com/tektoncd/triggers/releases/tag/v0.11.1
- https://github.com/tektoncd/dashboard/releases/tag/v0.13.0
- https://github.com/tektoncd/operator/releases/tag/v0.15.2-1