### PR TITLE
Update required-images.txt

### DIFF
--- a/mirror/required-images.txt
+++ b/mirror/required-images.txt
@@ -14,4 +14,4 @@
 
 kubernetesui/metrics-scraper:v1.0.6
 kubernetesui/dashboard:v2.3.1
-
+k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0


### PR DESCRIPTION
# 如果可以拉取这个image的所有tag会更好，目前这个tag是使用Helm安装Prometheus需要的（是follow的AWS官方文档的步骤）
k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.0